### PR TITLE
Refactor + add lodash style tools for processing statements

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,26 @@
+/**
+ * Context
+ *
+ * Temporary file that contains things that shouldn't be in this module
+ */
+
+// contextual information we need to do the next stage of processing
+var resourceContext = {
+    posts: {
+        name: 'posts',
+        propAliases: {author: 'author.slug', tags: 'tags.slug', tag: 'tags.slug'},
+        relations: []
+    },
+    tags: {
+        name: 'tags',
+        propAliases: {},
+        relations: []
+    },
+    users: {
+        name: 'users',
+        propAliases: {role: 'roles.name'},
+        relations: []
+    }
+};
+
+module.exports = resourceContext;

--- a/lib/gql.js
+++ b/lib/gql.js
@@ -19,4 +19,5 @@ var parse = exports.parse = function (input, resource_type, aliases) {
     return parser.parse(input, resource_type, aliases);
 };
 
-var knexify = exports.knexify = require('./knexify');
+exports.knexify = require('./knexify');
+exports.json    = require('./lodash-stmt');

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -7,37 +7,21 @@
  */
 
 var _ = require('lodash'),
+    resourceContext = require('./context'),
+
     // local functions
     processFilter,
     buildWhere,
-    knexify,
+    whereType;
 
-    // contextual information we need to do the next stage of processing
-    resourceContext = {
-        posts: {
-            name: 'posts',
-            propAliases: {author: 'author.slug', tags: 'tags.slug', tag: 'tags.slug'},
-            relations: []
-        },
-        tags: {
-            name: 'tags',
-            propAliases: {},
-            relations: []
-        },
-        users: {
-            name: 'users',
-            propAliases: {role: 'roles.name'},
-            relations: []
-        }
-    };
+_.mixin(require('./lodash-stmt'));
 
-
+// @TODO: remove this function
 processFilter = function processFilter(filter, context) {
     var joins = [],
         addJoin,
         expandAlias,
-        processProperty,
-        processProperties;
+        processProperty;
 
     addJoin = function addJoin(join) {
         if (joins.indexOf(join) === -1) {
@@ -80,21 +64,40 @@ processFilter = function processFilter(filter, context) {
         return property;
     };
 
-    processProperties = function processProperties(statements) {
-        _.each(statements, function (statement) {
-            if (statement.group) {
-                processProperties(statement.group);
-            } else {
-                statement.prop = processProperty(statement.prop)
-            }
-        });
-    };
-
-    processProperties(filter.statements);
+    // Loop through and process all the properties, really should be elsewhere
+    _.eachStatement(filter.statements, function (statement) {
+        statement.prop = processProperty(statement.prop);
+    });
 
     filter.joins = joins;
 
     return filter;
+};
+
+/**
+ * Detect Where Type
+ * @param statement
+ * @param index
+ * @returns {string}
+ */
+whereType = function whereType(statement, index) {
+    var whereFunc = 'andWhere';
+    if (index === 0) {
+        whereFunc = 'where';
+
+    } else if (statement.func === 'or') {
+        whereFunc = 'orWhere';
+    }
+
+    if (statement.value === null) {
+        if (statement.func === 'or') {
+            whereFunc = statement.op === 'IS NOT' ? 'orWhereNotNull' : 'orWhereNull';
+        } else {
+            whereFunc = statement.op === 'IS NOT' ? 'whereNotNull' : 'whereNull';
+        }
+    }
+
+    return whereFunc;
 };
 
 /**
@@ -105,43 +108,35 @@ processFilter = function processFilter(filter, context) {
  * @returns {*}
  */
 buildWhere = function buildWhere(qb, statements) {
-    _.each(statements, function(statement, index) {
-        var whereFunc = 'andWhere';
-        if (index === 0) {
-            whereFunc = 'where';
-
-        } else if (statement.func === 'or') {
-            whereFunc = 'orWhere';
-        }
-
-        if (statement.value === null) {
-            if (statement.func === 'or') {
-                whereFunc = statement.op === 'IS NOT' ? 'orWhereNotNull' : 'orWhereNull';
-            } else {
-                whereFunc = statement.op === 'IS NOT' ? 'whereNotNull' : 'whereNull';
-            }
-        }
-
-        // Is this a Group?
-        if (statement.group) {
-            qb[whereFunc](function (_qb) {
+    _.eachStatement(
+        statements,
+        function single(statement, index) {
+            // @TODO - validate value vs id here, to ensure we only pass valid things into where
+            qb[whereType(statement, index)](statement.prop, statement.op, statement.value);
+        },
+        function group(statement, index) {
+            qb[whereType(statement, index)](function (_qb) {
                 buildWhere(_qb, statement.group);
             });
-        } else {
-            // @TODO - validate value vs id here, to ensure we only pass valid things into where
-            qb[whereFunc](statement.prop, statement.op, statement.value);
         }
-    });
+    );
 };
 
-knexify = function knexify(qb, filter) {
+/**
+ * Knexify
+ * Converts a 'filter' from a set of statements in JSON form, into a set of `where` calls on a queryBuilder object
+  * This wrapping call to buildWhere should eventually be removed
+ *
+ * @param qb
+ * @param filter
+ * @returns {object} queryBuilder
+ */
+module.exports = function knexify(qb, filter) {
     filter = processFilter(filter, resourceContext[qb._single.table]);
     buildWhere(qb, filter.statements);
     // return modified queryBuilder object for chaining
     return qb;
 };
-
-module.exports = knexify;
 
 // For testing only
 module.exports._buildWhere = buildWhere;

--- a/lib/lodash-stmt.js
+++ b/lib/lodash-stmt.js
@@ -1,0 +1,37 @@
+/**
+ * # Lodash Statement
+ *
+ * A set of lodash-like statements, heavily dependent on lodash,
+ * for operating on the JSON statement objects returned from GQL
+ */
+
+var _ = require('lodash');
+
+/**
+ * ## Each Statement
+ *
+ * Call a function on every statement
+ *
+ * E.g. eachStatement([..statements], function (statement, index) { statement.prop = statement.prop.toLowerCase(); });
+ *
+ * @param {Array} statements - an array of statements from a GQL JSON object
+ * @param {Function} func - function to call for each individual statement
+ * @param {Function} [groupFunc] - optionally provide a function to call for groups instead of automatic recursion
+ */
+var eachStatement = function eachStatement(statements, func, groupFunc) {
+    _.each(statements, function (statement, index) {
+        if (_.has(statement, 'group')) {
+            if (groupFunc) {
+                groupFunc(statement, index);
+            } else {
+                eachStatement(statement.group, func, groupFunc);
+            }
+        } else {
+            func(statement, index);
+        }
+    });
+};
+
+module.exports = {
+    eachStatement: eachStatement
+};

--- a/lib/lodash-stmt.js
+++ b/lib/lodash-stmt.js
@@ -9,7 +9,8 @@ var _ = require('lodash'),
     
     matchStatement,
     eachStatement,
-    findStatement;
+    findStatement,
+    mergeStatements;
 
 /**
  * ## Match Statement
@@ -88,8 +89,57 @@ findStatement = function findStatement(statements, match, keys) {
     });
 };
 
+/**
+ * ## Merge Statements
+ *
+ * Take multiple statements, or statement objects and combines them into a valid statement object, using 'and'
+ *
+ * E.g.
+ * ```
+ * mergeStatements(
+ *   {statements: [
+ *     {op: "=", value: "photo", prop: "tag"},
+ *     {op: "=", value: "video", prop: "tag", func: "or"}
+ *   ]},
+ *   {prop: 'page', op: '=', value: false}
+ * );
+ * ```
+ *
+ * Returns:
+ * ```
+ * {statements: [
+ *     {op: "=", value: "photo", prop: "tag"},
+ *     {op: "=", value: "video", prop: "tag", func: "or"}
+ *     {op: "=", value: false, prop: "page", func "and"}
+ *   ]},
+ * ```
+ *
+ * @param {...Object} statements
+ * @returns {{statements: *}}
+ */
+mergeStatements = function mergeStatements(/* statements */) {
+    var statementsArray = _.reduce(arguments, function (array, arg) {
+        if (!arg) { return array; }
+
+        if (_.has(arg, 'statements')) {
+            if (array.length !== 0 && !_.isEmpty(arg.statements)) {
+                arg.statements[0].func = 'and';
+            }
+            array = array.concat(arg.statements);
+        } else {
+            if (array.length !== 0) { arg.func = 'and'; }
+            array.push(arg);
+        }
+
+        return array;
+    }, []);
+
+    return {statements: statementsArray};
+};
+
 module.exports = {
     matchStatement: matchStatement,
     eachStatement: eachStatement,
-    findStatement: findStatement
+    findStatement: findStatement,
+    mergeStatements: mergeStatements
 };

--- a/lib/lodash-stmt.js
+++ b/lib/lodash-stmt.js
@@ -10,6 +10,7 @@ var _ = require('lodash'),
     matchStatement,
     eachStatement,
     findStatement,
+    rejectStatements,
     mergeStatements,
     printStatements;
 
@@ -91,6 +92,42 @@ findStatement = function findStatement(statements, match, keys) {
 };
 
 /**
+ * ## Reject Statements
+ *
+ * As with _.reject, return a statement array without any statements for which 'func' returns true
+ * Also manages ensuring that groups and properties are cleaned up properly when something near them is removed
+ *
+ * E.g.  Returns `[{op: "=", value: "video", prop: "tag"}]`
+ * ```
+ * rejectStatements([
+ *   {op: "=", value: "photo", prop: "tag"},
+ *   {op: "=", value: "video", prop: "tag", func: "or"}
+ * ], function testFunc(statement) { return findStatement(statement, {value: "photo"}); });
+ * ```
+ *
+ * @param {Array} statements - an array of statements from a GQL JSON object
+ * @param {Function} func - a function which takes a statement and returns true or false
+ * @returns {Array}
+ */
+rejectStatements = function rejectStatements(statements, func) {
+    return _.reject(statements, function (statement, index) {
+        var result;
+
+        if (_.has(statement, 'group')) {
+            statement.group = rejectStatements(statement.group, func);
+            result = _.isEmpty(statement.group);
+        } else {
+            result = func(statement);
+        }
+
+        if (result && index === 0 && statements[index+1] && statements[index+1].func) {
+            delete statements[index+1].func;
+        }
+        return result;
+    });
+};
+
+/**
  * ## Merge Statements
  *
  * Take multiple statements, or statement objects and combines them into a valid statement object, using 'and'
@@ -165,6 +202,7 @@ module.exports = {
     matchStatement: matchStatement,
     eachStatement: eachStatement,
     findStatement: findStatement,
+    rejectStatements: rejectStatements,
     mergeStatements: mergeStatements,
     printStatements: printStatements
 };

--- a/lib/lodash-stmt.js
+++ b/lib/lodash-stmt.js
@@ -10,7 +10,8 @@ var _ = require('lodash'),
     matchStatement,
     eachStatement,
     findStatement,
-    mergeStatements;
+    mergeStatements,
+    printStatements;
 
 /**
  * ## Match Statement
@@ -137,9 +138,33 @@ mergeStatements = function mergeStatements(/* statements */) {
     return {statements: statementsArray};
 };
 
+/**
+ * ## Print statements
+ *
+ * Recursively print out a statement object, including statements inside of groups
+ * Used for debugging, because console.log only prints a few levels deep
+ *
+ * @param {Array} statements - an array of statements from a GQL JSON object
+ * @param {integer} indent - indent size to start with
+ */
+printStatements = function printStatements(statements, indent) {
+    indent = indent || 0;
+    function print(indent /* strs */) {
+        var strs = [_.fill(Array(indent), ' ').join('')].concat(Array.prototype.slice.call(arguments, 1));
+        console.log.apply(this, strs);
+    }
+    eachStatement(statements, function single(statement) {
+        print(indent, statement);
+    }, function group(statement) {
+        print(indent, 'group', statement.func);
+        printStatements(statement.group, indent + 1);
+    });
+};
+
 module.exports = {
     matchStatement: matchStatement,
     eachStatement: eachStatement,
     findStatement: findStatement,
-    mergeStatements: mergeStatements
+    mergeStatements: mergeStatements,
+    printStatements: printStatements
 };

--- a/lib/lodash-stmt.js
+++ b/lib/lodash-stmt.js
@@ -5,7 +5,35 @@
  * for operating on the JSON statement objects returned from GQL
  */
 
-var _ = require('lodash');
+var _ = require('lodash'),
+    
+    matchStatement,
+    eachStatement,
+    findStatement;
+
+/**
+ * ## Match Statement
+ *
+ * Determine if a statement matches a given object
+ *
+ * E.g.
+ * matchStatement({prop: 'page', op: '=', value: false}, {prop: 'page'}) => true
+ * matchStatement({prop: 'page', op: '=', value: false}, {value: true}) => false
+ * matchStatement({prop: 'tag.slug', op: 'IN', value: ['a', 'b']}, {prop: /^tag/, op: 'IN'}) => true
+ *
+ * @param {Object} statement - a single statement from a GQL JSON object
+ * @param {Object} match - a set of key, value pairs to match against
+ * @returns {boolean} does match
+ */
+matchStatement = function matchStatement(statement, match) {
+    return _.every(match, function (value, key) {
+        if (_.isRegExp(value)) {
+            return _.has(statement, key) && value.test(statement[key]);
+        } else {
+            return _.has(statement, key) && value === statement[key];
+        }
+    })
+};
 
 /**
  * ## Each Statement
@@ -17,8 +45,8 @@ var _ = require('lodash');
  * @param {Array} statements - an array of statements from a GQL JSON object
  * @param {Function} func - function to call for each individual statement
  * @param {Function} [groupFunc] - optionally provide a function to call for groups instead of automatic recursion
- */
-var eachStatement = function eachStatement(statements, func, groupFunc) {
+ */    
+eachStatement = function eachStatement(statements, func, groupFunc) {
     _.each(statements, function (statement, index) {
         if (_.has(statement, 'group')) {
             if (groupFunc) {
@@ -32,6 +60,36 @@ var eachStatement = function eachStatement(statements, func, groupFunc) {
     });
 };
 
+/**
+ * ## Find Statement
+ *
+ * Recursively find if any statement in the array matches the given match object
+ *
+ * E.g. returns true:
+ * ```
+ * findStatement([
+ *   {op: "=", value: "photo", prop: "tag"},
+ *   {op: "=", value: "video", prop: "tag", func: "or"}
+ * ], {value: "video"});
+ * ```
+ *
+ * @param {Array} statements - an array of statements from a GQL JSON object
+ * @param {Object} match - an object full of key-value pairs to match against
+ * @param {string|Array} [keys] - only match on these keys
+ * @returns {boolean}
+ */
+findStatement = function findStatement(statements, match, keys) {
+    return _.any(statements, function (statement) {
+        if (_.has(statement, 'group')) {
+            return findStatement(statement.group, match, keys);
+        } else {
+            return matchStatement(statement, keys ? _.pick(match, keys) : match);
+        }
+    });
+};
+
 module.exports = {
-    eachStatement: eachStatement
+    matchStatement: matchStatement,
+    eachStatement: eachStatement,
+    findStatement: findStatement
 };

--- a/test/lodash-stmt_spec.js
+++ b/test/lodash-stmt_spec.js
@@ -1,0 +1,169 @@
+var should = require('should'),
+    sinon  = require('sinon'),
+    _      = require('lodash'),
+
+    sandbox = sinon.sandbox.create();
+
+    lodashStmt = require('../lib/lodash-stmt');
+
+describe('Lodash Stmt Functions', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('mixins', function () {
+        beforeEach(function () {
+            _.mixin(lodashStmt);
+        });
+
+        afterEach(function () {
+            _.noConflict();
+        });
+
+        it('should provide eachStatement', function () {
+            should.exist(_.eachStatement);
+        });
+    });
+
+    describe('eachStatement', function () {
+        var eachStatement = lodashStmt.eachStatement;
+        it('should do nothing for empty statements', function () {
+            var single = sandbox.spy(),
+                group = sandbox.spy();
+
+            eachStatement([], single, group);
+
+            single.called.should.eql(false);
+            group.called.should.eql(false);
+        });
+
+        it('should iterate through flat statements', function () {
+            var single = sandbox.spy(),
+                group = sandbox.spy();
+
+            eachStatement([
+                {op: "!=", value: "joe", prop: "author"},
+                {op: "=", value: "photo", prop: "tag", func: "and"},
+                {op: "=", value: "video", prop: "tag", func: "or"}
+            ], single, group);
+
+            single.callCount.should.eql(3);
+            group.called.should.eql(false);
+        });
+
+        it('should iterate through group statements without a group function', function () {
+            var single = sandbox.spy();
+
+            eachStatement([
+                {op: "!=", value: "joe", prop: "author"},
+                {group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                ], func: "and"}
+            ], single);
+
+            single.callCount.should.eql(3);
+            single.getCall(0).calledWith({op: "!=", value: "joe", prop: "author"}).should.eql(true);
+            single.getCall(1).calledWith({op: "=", value: "photo", prop: "tag"}).should.eql(true);
+            single.getCall(2).calledWith({op: "=", value: "video", prop: "tag", func: "or"}).should.eql(true);
+        });
+
+        it('should iterate through nested group statements without a group function', function () {
+            var single = sandbox.spy();
+
+            eachStatement([
+                {op: "=", value: false, prop: "page"},
+                {op: "=", value: "published", prop: "status", func: "and"},
+                {group: [
+                    {op: "!=", value: "joe", prop: "author"},
+                    {group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                    ], func: "and"}
+                ], func: "and"}
+            ], single);
+
+            single.callCount.should.eql(5);
+            single.getCall(0).calledWith({op: "=", value: false, prop: "page"}).should.eql(true);
+            single.getCall(1).calledWith({op: "=", value: "published", prop: "status", func: "and"}).should.eql(true);
+            single.getCall(2).calledWith({op: "!=", value: "joe", prop: "author"}).should.eql(true);
+            single.getCall(3).calledWith({op: "=", value: "photo", prop: "tag"}).should.eql(true);
+            single.getCall(4).calledWith({op: "=", value: "video", prop: "tag", func: "or"}).should.eql(true);
+        });
+
+        it('should iterate through group statements with a group function', function () {
+            var single = sandbox.spy(),
+                group = sandbox.spy(function (statement) {
+                    testFunc(statement.group);
+                }),
+                testFunc = function (stuff) {
+                    eachStatement(stuff, single, group);
+                };
+
+            testFunc([
+                {op: "!=", value: "joe", prop: "author"},
+                {group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                ], func: "and"}
+            ]);
+
+
+            single.callCount.should.eql(3);
+            single.getCall(0).calledWith({op: "!=", value: "joe", prop: "author"}).should.eql(true);
+            single.getCall(1).calledWith({op: "=", value: "photo", prop: "tag"}).should.eql(true);
+            single.getCall(2).calledWith({op: "=", value: "video", prop: "tag", func: "or"}).should.eql(true);
+            group.callCount.should.eql(1);
+            group.getCall(0).calledWith({group: [
+                {op: "=", value: "photo", prop: "tag"},
+                {op: "=", value: "video", prop: "tag", func: "or"}
+            ], func: "and"}).should.eql(true);
+        });
+
+        it('should iterate through nested group statements with a group function', function () {
+            var single = sandbox.spy(),
+                group = sandbox.spy(function (statement) {
+                    testFunc(statement.group);
+                }),
+                testFunc = function (stuff) {
+                    eachStatement(stuff, single, group);
+                };
+
+            testFunc([
+                {op: "=", value: false, prop: "page"},
+                {op: "=", value: "published", prop: "status", func: "and"},
+                {group: [
+                    {op: "!=", value: "joe", prop: "author"},
+                    {group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                    ], func: "and"}
+                ], func: "and"}
+            ]);
+
+            single.callCount.should.eql(5);
+            single.getCall(0).calledWith({op: "=", value: false, prop: "page"}).should.eql(true);
+            single.getCall(1).calledWith({op: "=", value: "published", prop: "status", func: "and"}).should.eql(true);
+            single.getCall(2).calledWith({op: "!=", value: "joe", prop: "author"}).should.eql(true);
+            single.getCall(3).calledWith({op: "=", value: "photo", prop: "tag"}).should.eql(true);
+            single.getCall(4).calledWith({op: "=", value: "video", prop: "tag", func: "or"}).should.eql(true);
+
+            group.callCount.should.eql(2);
+            group.getCall(0).calledWith({group: [
+                {op: "!=", value: "joe", prop: "author"},
+                {
+                    group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                    ], func: "and"
+                }
+            ], func: "and"}).should.eql(true);
+
+            group.getCall(1).calledWith({group: [
+                {op: "=", value: "photo", prop: "tag"},
+                {op: "=", value: "video", prop: "tag", func: "or"}
+            ], func: "and"}).should.eql(true);
+        });
+    });
+});
+

--- a/test/lodash-stmt_spec.js
+++ b/test/lodash-stmt_spec.js
@@ -31,6 +31,10 @@ describe('Lodash Stmt Functions', function () {
         it('should provide findStatement', function () {
             should.exist(_.findStatement);
         });
+
+        it('should provide mergeStatements', function () {
+            should.exist(_.mergeStatements);
+        });
     });
 
     describe('matchStatement', function () {
@@ -269,6 +273,122 @@ describe('Lodash Stmt Functions', function () {
                 findStatement(statements, {prop: /^tag/}).should.eql(true);
                 findStatement(statements, {prop: 'page'}).should.eql(false);
             });
+        });
+    });
+
+    describe('mergeStatements', function () {
+        var mergeStatements = lodashStmt.mergeStatements;
+
+        describe('empty object', function () {
+            it('should return a valid statement object when passed no args', function () {
+                var result = mergeStatements();
+                result.should.eql({statements: []})
+            });
+
+            it('should return a valid statement object when passed undefined args', function () {
+                var result = mergeStatements(undefined, undefined);
+                result.should.eql({statements: []})
+            });
+
+            it('should return a valid statement object when passed null args', function () {
+                var result = mergeStatements(null, null);
+                result.should.eql({statements: []})
+            });
+        });
+
+        it('should merge two simple statements', function () {
+            var result = mergeStatements(
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published"}
+            );
+
+            result.should.eql({statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"}
+            ]})
+        });
+
+        it('should correctly merge null and a valid statement', function () {
+            var result = mergeStatements(
+                null,
+                {prop: "status", op: "=", value: "published"}
+            );
+
+            result.should.eql({statements: [
+                {prop: "status", op: "=", value: "published"}
+            ]})
+        });
+
+        it('should correctly merge undefined and a valid statement', function () {
+            var result = mergeStatements(
+                undefined,
+                {prop: "status", op: "=", value: "published"}
+            );
+
+            result.should.eql({statements: [
+                {prop: "status", op: "=", value: "published"}
+            ]})
+        });
+
+        it('should merge two statement objects', function () {
+            var obj1 = {statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"}
+            ]},
+                obj2 = {statements: [
+                    {op: "=", value: "photo", prop: "tag"},
+                    {op: "=", value: "video", prop: "tag", func: "or"}
+                ]},
+                result = mergeStatements(obj1, obj2);
+
+            result.should.eql({statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"},
+                {op: "=", value: "photo", prop: "tag", func: "and"},
+                {op: "=", value: "video", prop: "tag", func: "or"}
+            ]})
+        });
+
+        it('should merge two statement objects when one is empty', function () {
+            var obj1 = {statements: [
+                    {prop: "page", op: "=", value: false},
+                    {prop: "status", op: "=", value: "published", func: "and"}
+                ]},
+                obj2 = {statements: []},
+                result = mergeStatements(obj1, obj2);
+
+            result.should.eql({statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"}
+            ]})
+        });
+
+        it('should merge two statement objects when one is null', function () {
+            var obj1 = {statements: [
+                    {prop: "page", op: "=", value: false},
+                    {prop: "status", op: "=", value: "published", func: "and"}
+                ]},
+                obj2 = null,
+                result = mergeStatements(obj1, obj2);
+
+            result.should.eql({statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"}
+            ]})
+        });
+
+        it('should merge two statement objects when one is undefined', function () {
+            var obj1 = {statements: [
+                    {prop: "page", op: "=", value: false},
+                    {prop: "status", op: "=", value: "published", func: "and"}
+                ]},
+                obj2 = undefined,
+                result = mergeStatements(obj1, obj2);
+
+            result.should.eql({statements: [
+                {prop: "page", op: "=", value: false},
+                {prop: "status", op: "=", value: "published", func: "and"}
+            ]})
         });
     });
 });

--- a/test/lodash-stmt_spec.js
+++ b/test/lodash-stmt_spec.js
@@ -35,6 +35,10 @@ describe('Lodash Stmt Functions', function () {
         it('should provide mergeStatements', function () {
             should.exist(_.mergeStatements);
         });
+
+        it('should provide printStatements', function () {
+            should.exist(_.printStatements);
+        });
     });
 
     describe('matchStatement', function () {
@@ -389,6 +393,83 @@ describe('Lodash Stmt Functions', function () {
                 {prop: "page", op: "=", value: false},
                 {prop: "status", op: "=", value: "published", func: "and"}
             ]})
+        });
+    });
+
+    describe('printStatements', function () {
+        var printStatements = lodashStmt.printStatements,
+            consoleSpy;
+
+        it('should do nothing for empty statements', function () {
+            consoleSpy = sandbox.spy(console, 'log');
+
+            printStatements([]);
+
+            consoleSpy.called.should.eql(false);
+        });
+
+        it('should iterate through flat statements', function () {
+            consoleSpy = sandbox.spy(console, 'log');
+
+            printStatements([
+                {op: "!=", value: "joe", prop: "author"},
+                {op: "=", value: "photo", prop: "tag", func: "and"},
+                {op: "=", value: "video", prop: "tag", func: "or"}
+            ]);
+
+            consoleSpy.callCount.should.eql(3);
+            consoleSpy.getCall(0).args.should.eql(['', {op: "!=", value: "joe", prop: "author"}]);
+            consoleSpy.getCall(1).args.should.eql(['', {op: "=", value: "photo", prop: "tag", func: "and"}]);
+            consoleSpy.getCall(2).args.should.eql(['', {op: "=", value: "video", prop: "tag", func: "or"}]);
+        });
+
+        it('should iterate through group statements without a group function', function () {
+            consoleSpy = sandbox.spy(console, 'log');
+
+            printStatements([
+                {op: "!=", value: "joe", prop: "author"},
+                {
+                    group: [
+                        {op: "=", value: "photo", prop: "tag"},
+                        {op: "=", value: "video", prop: "tag", func: "or"}
+                    ], func: "and"
+                }
+            ]);
+
+            consoleSpy.callCount.should.eql(4);
+            consoleSpy.getCall(0).args.should.eql(['', {op: "!=", value: "joe", prop: "author"}]);
+            consoleSpy.getCall(1).args.should.eql(['', 'group', 'and']);
+            consoleSpy.getCall(2).args.should.eql([' ', {op: "=", value: "photo", prop: "tag"}]);
+            consoleSpy.getCall(3).args.should.eql([' ', {op: "=", value: "video", prop: "tag", func: "or"}]);
+        });
+
+        it('should iterate through nested group statements without a group function', function () {
+            consoleSpy = sandbox.spy(console, 'log');
+
+            printStatements([
+                {op: "=", value: false, prop: "page"},
+                {op: "=", value: "published", prop: "status", func: "and"},
+                {
+                    group: [
+                        {op: "!=", value: "joe", prop: "author"},
+                        {
+                            group: [
+                                {op: "=", value: "photo", prop: "tag"},
+                                {op: "=", value: "video", prop: "tag", func: "or"}
+                            ], func: "and"
+                        }
+                    ], func: "and"
+                }
+            ]);
+
+            consoleSpy.callCount.should.eql(7);
+            consoleSpy.getCall(0).args.should.eql(['', {op: "=", value: false, prop: "page"}]);
+            consoleSpy.getCall(1).args.should.eql(['', {op: "=", value: "published", prop: "status", func: "and"}]);
+            consoleSpy.getCall(2).args.should.eql(['', 'group', 'and']);
+            consoleSpy.getCall(3).args.should.eql([' ', {op: "!=", value: "joe", prop: "author"}]);
+            consoleSpy.getCall(4).args.should.eql([' ', 'group', 'and']);
+            consoleSpy.getCall(5).args.should.eql(['  ', {op: "=", value: "photo", prop: "tag"}]);
+            consoleSpy.getCall(6).args.should.eql(['  ', {op: "=", value: "video", prop: "tag", func: "or"}]);
         });
     });
 });


### PR DESCRIPTION
The idea here is I'm refactoring knexify to:

1. move out some of the code that really should not be in it (I want to convert it to a plugin for bookshelf if possible)
2. move the duplicate code that loops through statements and recursively loops through groups

I'm doing some work inside of Ghost, and found myself repeating the same recursive loop pattern, and so I think it makes sense to add tools for doing that to gql, and then move the context-aware code back out of gql into Ghost, but using these tools.

----

### Functionality:

The two tools provided here are `eachStatement` and `findStatement`. 

`eachStatement` takes a set of statements and a function to call for each statement. It optionally also takes an extra function to call for each group. It is used in knexify both with and without the optional group function, here's the simple example:

```
eachStatement(filter.statements, function (statement) {
    statement.prop = processProperty(statement.prop);
});
```

`findStatement` takes a set of statements, and then an object with the key value pairs you want to match. E.g. calling `findStatement(statements, {prop: 'page'})` would return true if any statement has `prop: 'page'` in it.

In some cases, you might want to pass it an entire statement to match against, and define which keys are the ones you care about.

E.g. calling `findStatement(statements, {prop: 'page', op: '=', value: true}, 'prop')` would do exactly the same as the previous example. 

You can pass arrays as the final arg to findStatement, or regexes as values also works e.g. ``findStatement(statements, {prop:  /^tags/, op: 'IN', value: 'stuff'}, ['prop', 'op'])` will return true if there is a statement which has a prop starting with 'tags' and the operator 'IN'.

---

### Usage:

There are currently two ways that you 'could' use these functions externally (e.g. in Ghost) and in the vein of naming things is hard, I can't decide which I prefer.

You could do:

```
var _ = require('lodash');
_.mixin(require('ghost-gql').json);

_.eachStatement(statements...);
```

Or you could do

```
var gql = require('ghost-gql');
gql.json.eachStatement(statements...);
```

The `gql.json` part made sense to me as you're talking about the json format you get back from gql... however reading it back I'm not sure... perhaps I should just rename that to 'lodash' so that you get `_.mixin(require('ghost-gql').lodash);` or something similar.

