### PR TITLE
[wip]Add concept of namedProperties to context

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -9,17 +9,20 @@ var resourceContext = {
     posts: {
         name: 'posts',
         propAliases: {author: 'author.slug', tags: 'tags.slug', tag: 'tags.slug'},
-        relations: []
+        relations: ['tags', 'author'],
+        namedProperties: []
     },
     tags: {
         name: 'tags',
         propAliases: {},
-        relations: []
+        relations: [],
+        namedProperties: ['posts_count']
     },
     users: {
         name: 'users',
         propAliases: {role: 'roles.name'},
-        relations: []
+        relations: [],
+        namedProperties: ['posts_count']
     }
 };
 

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -47,7 +47,7 @@ processFilter = function processFilter(filter, context) {
         parts = property.split('.');
 
         // If length is 1, we only have a column name, add table name
-        if (parts.length === 1) {
+        if (parts.length === 1 && context.namedProperties.indexOf(parts[0]) === -1) {
             property = context.name ? context.name + '.' + property : property;
         }
 
@@ -55,10 +55,9 @@ processFilter = function processFilter(filter, context) {
         // This is sort of a hack for building joins and include params later
         // It almost certainly doesn't belong here
         if (parts.length > 1) {
-            addJoin(parts[0]);
-            //if (context.relations && context.relations.indexOf(parts[parts.length - 1]) > -1) {
-            //    addJoin(path);
-            //}
+            if (context.relations && context.relations.indexOf(parts[0]) > -1) {
+                addJoin(parts[0]);
+            }
         }
 
         return property;

--- a/test/knexify_spec.js
+++ b/test/knexify_spec.js
@@ -4,10 +4,11 @@ var should = require('should'),
     knexify = require('../lib/knexify');
 
 describe('Knexify', function () {
-    var postKnex, sandbox = sinon.sandbox.create();
+    var postKnex, tagKnex, sandbox = sinon.sandbox.create();
 
     beforeEach(function () {
         postKnex = knex('posts');
+        tagKnex = knex('tags');
         sandbox.spy(postKnex, 'where');
         sandbox.spy(postKnex, 'orWhere');
         sandbox.spy(postKnex, 'andWhere');
@@ -293,7 +294,7 @@ describe('Knexify', function () {
             postKnex.orWhereNotNull.calledOnce.should.eql(false);
         });
 
-        it('should correctly build a group query with a not null caluse', function () {
+        it('should correctly build a group query with a not null clause', function () {
             knexify(postKnex, {
                 statements: [
                     {op: "!=", value: "joe", prop: "author"},
@@ -327,6 +328,32 @@ describe('Knexify', function () {
             postKnex.whereNotNull.calledOnce.should.eql(false);
             postKnex.orWhereNull.calledOnce.should.eql(false);
             postKnex.orWhereNotNull.calledOnce.should.eql(false);
+        });
+    });
+
+    describe('Joins', function () {
+        it('post should have joins', function () {
+            var filter = {
+                statements: [
+                    {op: "!=", value: "joe", prop: "author"},
+                    {op: "=", value: "photo", prop: "tag"}
+                ]
+            };
+            knexify(postKnex, filter);
+
+            filter.joins.should.eql(['author', 'tags']);
+        });
+
+        it('tag should not have any joins', function () {
+            var filter = {
+                statements: [
+                    {op: "!=", value: "joe", prop: "name"},
+                    {op: "!=", value: "joe", prop: "posts.name"}
+                ]
+            };
+            knexify(tagKnex, filter);
+
+            filter.joins.should.eql([]);
         });
     });
 });


### PR DESCRIPTION
Note: all of this should eventually be removed from GQL and configured in Ghost
- add namedProperties, which don't require a table (e.g. posts_count)
- use relations, rather than adding all joins
- add some tests
