### PR TITLE
extend: number regex to support more use cases

### DIFF
--- a/src/gql.l
+++ b/src/gql.l
@@ -16,7 +16,7 @@ escapable                    ['"\+\,\(\)\>\<=\[\]]
 'TRUE'                                                      return 'TRUE';
 'FALSE'                                                     return 'FALSE';
 [a-zA-Z_][a-zA-Z0-9_\.]*[:]                                 return 'PROP';
-[0-9]+("."[0-9]+)?\b                                        return 'NUMBER';
+[0-9]+(\.[0-9]+)?\b(?![\-])                                 return 'NUMBER';
 '['                                                         return 'LBRACKET';
 ']'                                                         return 'RBRACKET';
 {badcharsincnot}(\\{escapable}|{badcharsnonot})+            return 'LITERAL';

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -25,6 +25,12 @@ describe('Parser', function () {
                     {prop: 'author', op: '=', value: 'Joe Bloggs'}
                 ]
             });
+
+            gql.parse('author:123-test').should.eql({
+                statements: [
+                    {prop: 'author', op: '=', value: '123-test'}
+                ]
+            });
         });
 
         it('can parse not equals', function () {


### PR DESCRIPTION
We can now support the following use case with GQL. 

closes https://github.com/TryGhost/Ghost/issues/7075#issuecomment-232312870

I've extended the regex for matching numbers. If a number is followed by a hyphen, then it does not get matched.