### PR TITLE
🛠 Switch from jslint & jscs to eslint@4.8.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,112 @@
+{
+    "env": {
+        "node": true,
+        "mocha": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {},
+    "rules": {
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
+        "brace-style": [
+            "error",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
+        ],
+        "camelcase": [
+            "error",
+            {
+                "properties": "never"
+            }
+        ],
+        "comma-dangle": "error",
+        "comma-style": "error",
+        "curly": [
+            "error",
+            "all"
+        ],
+        "dot-notation": "error",
+        "eol-last": "error",
+        "eqeqeq": "error",
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "key-spacing": "error",
+        "keyword-spacing": "error",
+        "linebreak-style": "error",
+        "max-len": [
+            "error",
+            {
+                "code": 120,
+                "ignoreComments": true,
+                "ignoreStrings": true,
+                "ignoreTemplateLiterals": true,
+                "ignoreRegExpLiterals": true
+            }
+        ],
+        "new-cap": "error",
+        "new-parens": "error",
+        "no-caller": "error",
+        "no-console": "off",
+        "no-empty": "error",
+        "no-lonely-if": "error",
+        "no-multiple-empty-lines": "error",
+        "no-new": "error",
+        "no-plusplus": "error",
+        "no-trailing-spaces": "error",
+        "no-undef": "error",
+        "no-unused-vars": "error",
+        "no-use-before-define": "error",
+        "no-with": "error",
+        "object-curly-newline": [
+            "error",
+            {
+                "consistent": true
+            }
+        ],
+        "object-curly-spacing": "error",
+        "padded-blocks": [
+            "error",
+            "never"
+        ],
+        "quote-props": [
+            "error",
+            "as-needed"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "space-before-blocks": "error",
+        "space-before-function-paren": [
+            "error",
+            {
+                "anonymous": "always",
+                "named": "never"
+            }
+        ],
+        "space-in-parens": [
+            "error",
+            "never"
+        ],
+        "space-infix-ops": "error",
+        "space-unary-ops": [
+            "error",
+            {
+                "words": false,
+                "nonwords": false
+            }
+        ],
+        "spaced-comment": "error",
+        "template-curly-spacing": "error",
+        "yoda": "error"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Filter query language for Ghost",
   "main": "index.js",
   "scripts": {
-    "lint": "jshint lib/*.js test/*.js && jscs lib/*.js test/*.js",
+    "lint": "eslint lib test/*_spec.js",
     "test": "npm run build && npm run lint && mocha",
     "build": "jison src/gql.y src/gql.l -o dist/parser.js",
     "coverage": "istanbul cover -x src --dir=test/coverage --report=lcov _mocha -- test/*_spec.js",
@@ -26,10 +26,9 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
+    "eslint": "4.8.0",
     "istanbul": "0.4.5",
     "jison": "0.4.16",
-    "jscs": "2.8.0",
-    "jshint": "2.8.0",
     "knex": "0.8.6",
     "mocha": "3.5.3",
     "npm-release": "1.0.0",

--- a/test/gql_spec.js
+++ b/test/gql_spec.js
@@ -1,4 +1,3 @@
-/* globals describe, it */
 var gql = require('../lib/gql'),
     knex = require('knex')({}),
     toSQL;

--- a/test/knexify_spec.js
+++ b/test/knexify_spec.js
@@ -1,4 +1,3 @@
-/* globals describe, beforeEach, afterEach, it */
 var sinon  = require('sinon'),
     knex = require('knex')({}),
     knexify = require('../lib/knexify');

--- a/test/lexer_spec.js
+++ b/test/lexer_spec.js
@@ -1,4 +1,3 @@
-/* globals describe, it */
 var gql = require('../lib/gql');
 
 describe('Lexer', function () {

--- a/test/lodash-stmt_spec.js
+++ b/test/lodash-stmt_spec.js
@@ -1,7 +1,6 @@
-/* globals describe, beforeEach, afterEach, it */
 var should = require('should'),
-    sinon  = require('sinon'),
-    _      = require('lodash'),
+    sinon = require('sinon'),
+    _ = require('lodash'),
 
     sandbox = sinon.sandbox.create(),
 
@@ -98,10 +97,12 @@ describe('Lodash Stmt Functions', function () {
 
             eachStatement([
                 {op: '!=', value: 'joe', prop: 'author'},
-                {group: [
+                {
+                    group: [
                         {op: '=', value: 'photo', prop: 'tag'},
                         {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ], func: 'and'}
+                    ], func: 'and'
+                }
             ], single);
 
             single.callCount.should.eql(3);
@@ -116,13 +117,17 @@ describe('Lodash Stmt Functions', function () {
             eachStatement([
                 {op: '=', value: false, prop: 'page'},
                 {op: '=', value: 'published', prop: 'status', func: 'and'},
-                {group: [
-                    {op: '!=', value: 'joe', prop: 'author'},
-                    {group: [
-                        {op: '=', value: 'photo', prop: 'tag'},
-                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                    ], func: 'and'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '!=', value: 'joe', prop: 'author'},
+                        {
+                            group: [
+                                {op: '=', value: 'photo', prop: 'tag'},
+                                {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                            ], func: 'and'
+                        }
+                    ], func: 'and'
+                }
             ], single);
 
             single.callCount.should.eql(5);
@@ -136,7 +141,7 @@ describe('Lodash Stmt Functions', function () {
         it('should iterate through group statements with a group function', function () {
             var single = sandbox.spy(),
                 group = sandbox.spy(function (statement) {
-                    testFunc(statement.group);
+                    testFunc(statement.group);  // eslint-disable-line no-use-before-define
                 }),
                 testFunc = function (stuff) {
                     eachStatement(stuff, single, group);
@@ -144,10 +149,12 @@ describe('Lodash Stmt Functions', function () {
 
             testFunc([
                 {op: '!=', value: 'joe', prop: 'author'},
-                {group: [
+                {
+                    group: [
                         {op: '=', value: 'photo', prop: 'tag'},
                         {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ], func: 'and'}
+                    ], func: 'and'
+                }
             ]);
 
             single.callCount.should.eql(3);
@@ -155,16 +162,18 @@ describe('Lodash Stmt Functions', function () {
             single.getCall(1).calledWith({op: '=', value: 'photo', prop: 'tag'}).should.eql(true);
             single.getCall(2).calledWith({op: '=', value: 'video', prop: 'tag', func: 'or'}).should.eql(true);
             group.callCount.should.eql(1);
-            group.getCall(0).calledWith({group: [
-                {op: '=', value: 'photo', prop: 'tag'},
-                {op: '=', value: 'video', prop: 'tag', func: 'or'}
-            ], func: 'and'}).should.eql(true);
+            group.getCall(0).calledWith({
+                group: [
+                    {op: '=', value: 'photo', prop: 'tag'},
+                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                ], func: 'and'
+            }).should.eql(true);
         });
 
         it('should iterate through nested group statements with a group function', function () {
             var single = sandbox.spy(),
                 group = sandbox.spy(function (statement) {
-                    testFunc(statement.group);
+                    testFunc(statement.group); // eslint-disable-line no-use-before-define
                 }),
                 testFunc = function (stuff) {
                     eachStatement(stuff, single, group);
@@ -173,13 +182,17 @@ describe('Lodash Stmt Functions', function () {
             testFunc([
                 {op: '=', value: false, prop: 'page'},
                 {op: '=', value: 'published', prop: 'status', func: 'and'},
-                {group: [
-                    {op: '!=', value: 'joe', prop: 'author'},
-                    {group: [
-                        {op: '=', value: 'photo', prop: 'tag'},
-                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                    ], func: 'and'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '!=', value: 'joe', prop: 'author'},
+                        {
+                            group: [
+                                {op: '=', value: 'photo', prop: 'tag'},
+                                {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                            ], func: 'and'
+                        }
+                    ], func: 'and'
+                }
             ]);
 
             single.callCount.should.eql(5);
@@ -190,20 +203,24 @@ describe('Lodash Stmt Functions', function () {
             single.getCall(4).calledWith({op: '=', value: 'video', prop: 'tag', func: 'or'}).should.eql(true);
 
             group.callCount.should.eql(2);
-            group.getCall(0).calledWith({group: [
-                {op: '!=', value: 'joe', prop: 'author'},
-                {
-                    group: [
-                        {op: '=', value: 'photo', prop: 'tag'},
-                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                    ], func: 'and'
-                }
-            ], func: 'and'}).should.eql(true);
+            group.getCall(0).calledWith({
+                group: [
+                    {op: '!=', value: 'joe', prop: 'author'},
+                    {
+                        group: [
+                            {op: '=', value: 'photo', prop: 'tag'},
+                            {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                        ], func: 'and'
+                    }
+                ], func: 'and'
+            }).should.eql(true);
 
-            group.getCall(1).calledWith({group: [
-                {op: '=', value: 'photo', prop: 'tag'},
-                {op: '=', value: 'video', prop: 'tag', func: 'or'}
-            ], func: 'and'}).should.eql(true);
+            group.getCall(1).calledWith({
+                group: [
+                    {op: '=', value: 'photo', prop: 'tag'},
+                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                ], func: 'and'
+            }).should.eql(true);
         });
     });
 
@@ -268,10 +285,12 @@ describe('Lodash Stmt Functions', function () {
             it('should match inside a group', function () {
                 var statements = [
                     {op: '!=', value: 'joe', prop: 'author'},
-                    {group: [
-                        {op: '=', value: 'photo', prop: 'tag'},
-                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                    ], func: 'and'}
+                    {
+                        group: [
+                            {op: '=', value: 'photo', prop: 'tag'},
+                            {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                        ], func: 'and'
+                    }
                 ];
 
                 findStatement(statements, {value: 'photo'}).should.eql(true);
@@ -314,27 +333,33 @@ describe('Lodash Stmt Functions', function () {
         it('should filter out a statement from a group', function () {
             var statements = [
                 {op: '!=', value: 'joe', prop: 'author'},
-                {group: [
-                    {op: '=', value: 'photo', prop: 'tag'},
-                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                    ], func: 'and'
+                }
             ];
 
             rejectStatements(statements, testFunction({value: 'video'})).should.eql([
                 {op: '!=', value: 'joe', prop: 'author'},
-                {group: [
-                    {op: '=', value: 'photo', prop: 'tag'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: 'photo', prop: 'tag'}
+                    ], func: 'and'
+                }
             ]);
         });
 
         it('should remove group if all statements are removed', function () {
             var statements = [
                 {op: '!=', value: 'joe', prop: 'author'},
-                {group: [
-                    {op: '=', value: 'photo', prop: 'tag'},
-                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                    ], func: 'and'
+                }
             ];
 
             rejectStatements(statements, testFunction({prop: 'tag'})).should.eql([
@@ -357,47 +382,59 @@ describe('Lodash Stmt Functions', function () {
             var statements = [
                 {op: '=', value: 'photo', prop: 'tag'},
                 {op: '=', value: 'video', prop: 'tag', func: 'or'},
-                {group: [
-                    {op: '=', value: false, prop: 'page'},
-                    {op: '=', value: 'cameron', prop: 'author', func: 'or'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: false, prop: 'page'},
+                        {op: '=', value: 'cameron', prop: 'author', func: 'or'}
+                    ], func: 'and'
+                }
             ];
 
             rejectStatements(statements, testFunction({prop: 'page'})).should.eql([
                 {op: '=', value: 'photo', prop: 'tag'},
                 {op: '=', value: 'video', prop: 'tag', func: 'or'},
-                {group: [
-                    {op: '=', value: 'cameron', prop: 'author'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: 'cameron', prop: 'author'}
+                    ], func: 'and'
+                }
             ]);
         });
 
         it('should ensure first group has no func when removing a group from the front', function () {
             var statements = [
-                {group: [
-                    {op: '=', value: 'photo', prop: 'tag'},
-                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ]},
-                {group: [
-                    {op: '=', value: false, prop: 'page'},
-                    {op: '=', value: 'cameron', prop: 'author', func: 'or'}
-                ], func: 'and'}
+                {
+                    group: [
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                    ]
+                },
+                {
+                    group: [
+                        {op: '=', value: false, prop: 'page'},
+                        {op: '=', value: 'cameron', prop: 'author', func: 'or'}
+                    ], func: 'and'
+                }
             ];
 
             rejectStatements(statements, testFunction({prop: 'tag'})).should.eql([
-                {group: [
-                    {op: '=', value: false, prop: 'page'},
-                    {op: '=', value: 'cameron', prop: 'author', func: 'or'}
-                ]}
+                {
+                    group: [
+                        {op: '=', value: false, prop: 'page'},
+                        {op: '=', value: 'cameron', prop: 'author', func: 'or'}
+                    ]
+                }
             ]);
         });
 
         it('should ensure first statement has no func when removing a group from the front', function () {
             var statements = [
-                {group: [
-                    {op: '=', value: 'photo', prop: 'tag'},
-                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ]},
+                {
+                    group: [
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                    ]
+                },
                 {op: '=', value: false, prop: 'page', func: 'and'},
                 {op: '=', value: 'cameron', prop: 'author', func: 'or'}
             ];
@@ -435,10 +472,12 @@ describe('Lodash Stmt Functions', function () {
                 {prop: 'status', op: '=', value: 'published'}
             );
 
-            result.should.eql({statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'page', op: '=', value: false},
+                    {prop: 'status', op: '=', value: 'published', func: 'and'}
+                ]
+            });
         });
 
         it('should correctly merge null and a valid statement', function () {
@@ -447,9 +486,11 @@ describe('Lodash Stmt Functions', function () {
                 {prop: 'status', op: '=', value: 'published'}
             );
 
-            result.should.eql({statements: [
-                {prop: 'status', op: '=', value: 'published'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'status', op: '=', value: 'published'}
+                ]
+            });
         });
 
         it('should correctly merge undefined and a valid statement', function () {
@@ -458,70 +499,90 @@ describe('Lodash Stmt Functions', function () {
                 {prop: 'status', op: '=', value: 'published'}
             );
 
-            result.should.eql({statements: [
-                {prop: 'status', op: '=', value: 'published'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'status', op: '=', value: 'published'}
+                ]
+            });
         });
 
         it('should merge two statement objects', function () {
-            var obj1 = {statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'}
-            ]},
-                obj2 = {statements: [
-                    {op: '=', value: 'photo', prop: 'tag'},
-                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
-                ]},
+            var obj1 = {
+                    statements: [
+                        {prop: 'page', op: '=', value: false},
+                        {prop: 'status', op: '=', value: 'published', func: 'and'}
+                    ]
+                },
+                obj2 = {
+                    statements: [
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                    ]
+                },
                 result = mergeStatements(obj1, obj2);
 
-            result.should.eql({statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'},
-                {op: '=', value: 'photo', prop: 'tag', func: 'and'},
-                {op: '=', value: 'video', prop: 'tag', func: 'or'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'page', op: '=', value: false},
+                    {prop: 'status', op: '=', value: 'published', func: 'and'},
+                    {op: '=', value: 'photo', prop: 'tag', func: 'and'},
+                    {op: '=', value: 'video', prop: 'tag', func: 'or'}
+                ]
+            });
         });
 
         it('should merge two statement objects when one is empty', function () {
-            var obj1 = {statements: [
-                    {prop: 'page', op: '=', value: false},
-                    {prop: 'status', op: '=', value: 'published', func: 'and'}
-                ]},
+            var obj1 = {
+                    statements: [
+                        {prop: 'page', op: '=', value: false},
+                        {prop: 'status', op: '=', value: 'published', func: 'and'}
+                    ]
+                },
                 obj2 = {statements: []},
                 result = mergeStatements(obj1, obj2);
 
-            result.should.eql({statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'page', op: '=', value: false},
+                    {prop: 'status', op: '=', value: 'published', func: 'and'}
+                ]
+            });
         });
 
         it('should merge two statement objects when one is null', function () {
-            var obj1 = {statements: [
-                    {prop: 'page', op: '=', value: false},
-                    {prop: 'status', op: '=', value: 'published', func: 'and'}
-                ]},
+            var obj1 = {
+                    statements: [
+                        {prop: 'page', op: '=', value: false},
+                        {prop: 'status', op: '=', value: 'published', func: 'and'}
+                    ]
+                },
                 obj2 = null,
                 result = mergeStatements(obj1, obj2);
 
-            result.should.eql({statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'page', op: '=', value: false},
+                    {prop: 'status', op: '=', value: 'published', func: 'and'}
+                ]
+            });
         });
 
         it('should merge two statement objects when one is undefined', function () {
-            var obj1 = {statements: [
-                    {prop: 'page', op: '=', value: false},
-                    {prop: 'status', op: '=', value: 'published', func: 'and'}
-                ]},
+            var obj1 = {
+                    statements: [
+                        {prop: 'page', op: '=', value: false},
+                        {prop: 'status', op: '=', value: 'published', func: 'and'}
+                    ]
+                },
                 obj2,
                 result = mergeStatements(obj1, obj2);
 
-            result.should.eql({statements: [
-                {prop: 'page', op: '=', value: false},
-                {prop: 'status', op: '=', value: 'published', func: 'and'}
-            ]});
+            result.should.eql({
+                statements: [
+                    {prop: 'page', op: '=', value: false},
+                    {prop: 'status', op: '=', value: 'published', func: 'and'}
+                ]
+            });
         });
     });
 

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -1,6 +1,4 @@
-/* globals describe, it */
-/* jshint unused:false */
-var should = require('should'),
+var should = require('should'),  // eslint-disable-line no-unused-vars
     gql = require('../lib/gql');
 
 describe('Parser', function () {


### PR DESCRIPTION
- Add eslint@4.8.0
- Add .eslintrc.json based on the one in Ghost-CLI, but for ES5
- Fix a couple of minor linting issues with tests
- Remove mocha globals from all test files
- Update the `npm run lint` command