### PR TITLE
Support negation

### DIFF
--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -115,9 +115,19 @@ buildWhere = function buildWhere(qb, statements) {
                 // only tag filter requests in format: tag:photo+tag:cats fall into this path
                 // if tag:[photo, cats] then it will follow the other path
 
-                var subquery = 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `' + statement.value + '`';
+                /* eslint-disable quotes */
+                var subquery = "select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = '" + statement.value + "'";
+                /* eslint-enable quotes */
                 var inClause = statement.op === '!=' ? 'not in' : 'in';
-                qb[whereType(statement, index)]('posts.id', inClause, subquery);
+
+                var whereFunc = 'andWhereRaw';
+                if (index === 0) {
+                    whereFunc = 'whereRaw';
+                } else if (statement.func === 'or') {
+                    whereFunc = 'orWhereRaw';
+                }
+
+                qb[whereFunc]('posts.id ' + inClause + ' (' + subquery + ')')
             } else {
                 qb[whereType(statement, index)](statement.prop, statement.op, statement.value);
             }

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -114,8 +114,8 @@ buildWhere = function buildWhere(qb, statements) {
             // @TODO - validate value vs id here, to ensure we only pass valid things into where
             if (statement.prop === 'tags.slug') {
                 var subquery = knex('posts_tags').select('post_id').from('posts_tags').innerJoin('tags', 'posts_tags.tag_id', 'tags.id').where('tags.slug', '=', statement.value);
-                var whereClause = statement.op === '!=' ? 'whereNotIn' : 'whereIn';
-                qb[whereClause]('posts.id', subquery);
+                var inClause = statement.op === '!=' ? 'not in' : 'in';
+                qb[whereType(statement, index)]('posts.id', inClause, subquery);
             } else {
                 qb[whereType(statement, index)](statement.prop, statement.op, statement.value);
             }

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -112,8 +112,10 @@ buildWhere = function buildWhere(qb, statements) {
         statements,
         function single(statement, index) {
             // @TODO - validate value vs id here, to ensure we only pass valid things into where
-            if (statement.prop === 'tags.slug') {
-                // var subquery = knex('posts').select('post_id').from('posts_tags').innerJoin('tags', 'posts_tags.tag_id', 'tags.id').where('tags.slug', '=', statement.value);
+            if (statement.prop === 'tags.slug' && statement.op !== 'IN') {
+                //only tag filter requests in format: tag:photo+tag:cats fall into this path
+                //if tag:[photo, cats] then it will follow the other path
+
                 var subquery = 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `' + statement.value + '`';
                 var inClause = statement.op === '!=' ? 'not in' : 'in';
                 qb[whereType(statement, index)]('posts.id', inClause, subquery);

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -8,6 +8,7 @@
 
 var _ = require('lodash'),
     resourceContext = require('./context'),
+    knex = require('knex'),
 
     // local functions
     processFilter,
@@ -111,7 +112,13 @@ buildWhere = function buildWhere(qb, statements) {
         statements,
         function single(statement, index) {
             // @TODO - validate value vs id here, to ensure we only pass valid things into where
-            qb[whereType(statement, index)](statement.prop, statement.op, statement.value);
+            if (statement.prop === 'tags.slug') {
+                var subquery = knex('posts_tags').select('post_id').from('posts_tags').innerJoin('tags', 'posts_tags.tag_id', 'tags.id').where('tags.slug', '=', statement.value);
+                var whereClause = statement.op === '!=' ? 'whereNotIn' : 'whereIn';
+                qb[whereClause]('posts.id', subquery);
+            } else {
+                qb[whereType(statement, index)](statement.prop, statement.op, statement.value);
+            }
         },
         function group(statement, index) {
             qb[whereType(statement, index)](function (_qb) {

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -8,7 +8,6 @@
 
 var _ = require('lodash'),
     resourceContext = require('./context'),
-    // knex = require('knex'),
 
     // local functions
     processFilter,
@@ -113,8 +112,8 @@ buildWhere = function buildWhere(qb, statements) {
         function single(statement, index) {
             // @TODO - validate value vs id here, to ensure we only pass valid things into where
             if (statement.prop === 'tags.slug' && statement.op !== 'IN') {
-                //only tag filter requests in format: tag:photo+tag:cats fall into this path
-                //if tag:[photo, cats] then it will follow the other path
+                // only tag filter requests in format: tag:photo+tag:cats fall into this path
+                // if tag:[photo, cats] then it will follow the other path
 
                 var subquery = 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `' + statement.value + '`';
                 var inClause = statement.op === '!=' ? 'not in' : 'in';

--- a/lib/knexify.js
+++ b/lib/knexify.js
@@ -8,7 +8,7 @@
 
 var _ = require('lodash'),
     resourceContext = require('./context'),
-    knex = require('knex'),
+    // knex = require('knex'),
 
     // local functions
     processFilter,
@@ -113,7 +113,8 @@ buildWhere = function buildWhere(qb, statements) {
         function single(statement, index) {
             // @TODO - validate value vs id here, to ensure we only pass valid things into where
             if (statement.prop === 'tags.slug') {
-                var subquery = knex('posts_tags').select('post_id').from('posts_tags').innerJoin('tags', 'posts_tags.tag_id', 'tags.id').where('tags.slug', '=', statement.value);
+                // var subquery = knex('posts').select('post_id').from('posts_tags').innerJoin('tags', 'posts_tags.tag_id', 'tags.id').where('tags.slug', '=', statement.value);
+                var subquery = 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `' + statement.value + '`';
                 var inClause = statement.op === '!=' ? 'not in' : 'in';
                 qb[whereType(statement, index)]('posts.id', inClause, subquery);
             } else {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.4",
-    "sqlite": "^2.9.2"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "eslint": "4.19.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "sqlite": "^2.9.2"
   },
   "devDependencies": {
     "eslint": "4.19.1",

--- a/test/knexify_spec.js
+++ b/test/knexify_spec.js
@@ -283,15 +283,14 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
-                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
+                bindings: ['joe'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) or "posts"."id" in (?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') or posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             });
 
             var test = postKnex.toQuery();
-            var result = 'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') or "posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
+            var result = 'select * from "posts" where "author"."slug" != \'joe\' and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') or posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             test.should.eql(
                 result
             );

--- a/test/knexify_spec.js
+++ b/test/knexify_spec.js
@@ -358,15 +358,14 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
-                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
+                bindings: ['joe'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) and "posts"."id" in (?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') and posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             });
 
             postKnex.toQuery().should.eql(
-                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') and "posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
+                'select * from "posts" where "author"."slug" != \'joe\' and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') and posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             );
 
             postKnex.where.calledOnce.should.eql(true);
@@ -394,15 +393,14 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
-                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
+                bindings: ['joe'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) and "posts"."id" not in (?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') and posts.id not in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             });
 
             postKnex.toQuery().should.eql(
-                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') and "posts"."id" not in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
+                'select * from "posts" where "author"."slug" != \'joe\' and (posts.id in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'photo\') and posts.id not in (select post_id from posts_tags inner join tags on posts_tags.tag_id = tags.id where tags.slug = \'video\'))'
             );
 
             postKnex.where.calledOnce.should.eql(true);

--- a/test/knexify_spec.js
+++ b/test/knexify_spec.js
@@ -283,14 +283,17 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'photo', 'video'],
+                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
+                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?) or "posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) or "posts"."id" in (?))'
             });
 
-            postKnex.toQuery().should.eql(
-                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'photo\') or "posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'video\'))'
+            var test = postKnex.toQuery();
+            var result = 'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') or "posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
+            test.should.eql(
+                result
             );
 
             postKnex.where.calledOnce.should.eql(true);
@@ -356,14 +359,15 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'photo', 'video'],
+                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
+                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?) and "posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) and "posts"."id" in (?))'
             });
 
             postKnex.toQuery().should.eql(
-                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'photo\') and "posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'video\'))'
+                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') and "posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
             );
 
             postKnex.where.calledOnce.should.eql(true);
@@ -391,14 +395,15 @@ describe('Knexify', function () {
 
             // Check the output from both toSQL and toQuery - this emulates calling the query twice for pagination
             postKnex.toSQL().should.eql({
-                bindings: ['joe', 'photo', 'video'],
+                bindings: ['joe', 'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`',
+                    'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`'],
                 method: 'select',
                 options: {},
-                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?) and "posts"."id" not in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = ?))'
+                sql: 'select * from "posts" where "author"."slug" != ? and ("posts"."id" in (?) and "posts"."id" not in (?))'
             });
 
             postKnex.toQuery().should.eql(
-                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'photo\') and "posts"."id" not in (select "post_id" from "posts_tags" inner join "tags" on "posts_tags"."tag_id" = "tags"."id" where "tags"."slug" = \'video\'))'
+                'select * from "posts" where "author"."slug" != \'joe\' and ("posts"."id" in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `photo`\') and "posts"."id" not in (\'select `post_id` from `posts_tags` inner join `tags` on `posts_tags`.`tag_id` = `tags`.`id` where `tags`.`slug` = `video`\'))'
             );
 
             postKnex.where.calledOnce.should.eql(true);


### PR DESCRIPTION
proposed solution to support different filtering around tags in ghost which supports many-to-many relationships.  Some sample filters include: filter="tag:sports+tag:cats" and filter="tag:sports+tag:-cats"

Addresses: issue #16 