### PR TITLE
Run linting with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ The conversion from GQL -> JSON is performed via a [JISON](http://zaach.github.i
 
 In the `/src/` folder is a .l and a .y file used by JISON to generate the parser. `gql.l` is the lexer or tokenizer that defines all of the symbols that GQL can understand. `gql.y` is the grammar, it defines the rules about in what order the symbols must appear. If you make changes to `gql.l` or `gql.y`, you'll need to run `npm run build` in order to generate a new version of the parser in `/dist/`.
 
+## Development
+
+### Testing
+- `yarn test`
+- `yarn coverage`
+- `yarn lint`
+
+### Publish
+- `yarn ship`
+
 # Copyright & License
 
 Copyright (c) 2015-2018 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "jison src/gql.y src/gql.l -o dist/parser.js",
     "lint": "eslint lib test/*_spec.js",
-    "test": "yarn build && yarn lint && NODE_ENV=testing mocha -- $(find test -name '*_spec.js')",
+    "test": "yarn build && NODE_ENV=testing mocha -- $(find test -name '*_spec.js')",
+    "posttest": "yarn lint",
     "coverage": "NODE_ENV=testing istanbul cover --dir test/coverage _mocha -- $(find test -name '*._spec.js')",
     "preship": "yarn test",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push --follow-tags; fi"


### PR DESCRIPTION
refs TryGhost/Team#112

- added `postest` to scripts to run linting after the tests
- updated README to incl. testing and shipping scripts